### PR TITLE
Add global searchparty_c_l_user_map_to_leader

### DIFF
--- a/plugin/SearchParty.vim
+++ b/plugin/SearchParty.vim
@@ -65,10 +65,21 @@ function! SPLoadUserMaps()
     endif
   endif
 
+  let l:replacement_done = 0
+
   for line in readfile(sp_user_maps_file)
     if line =~ '^\s*\(".*\)\?$'
       continue
     endif
+
+    if exists('g:searchparty_c_l_user_map_to_leader')
+      if l:replacement_done == 0 && line =~# 'nmap\s\+<silent>\s\+<c-l>'
+        exe 'nnoremap <silent> <leader>l    <c-l><Plug>SearchPartyHighlightClear'
+        let l:replacement_done = 1
+        continue
+      endif
+    endif
+
     if line !~ '^\s*.\(nore\)\?map'
       call s:Carp('SPLoadUserMaps: Not a map command! (' . line . ')')
       continue


### PR DESCRIPTION
Proof of concept to explain what I'm thinking of.

The idea is that all the other maps are good.  But `<c-l>` is a common user map, that's the only one I don't want to import.  Since the mapping is common, and all SearchParty's other mappings use `<leader>`, I imagine other people might also dislike only that one `<c-l>`.  I'd rather specify a variable in my `~/.vimrc` than write to a different file, so I'm hoping for a variable.

Actually, after doing this, I now realize I can avoid the map file by setting `let g:searchparty_load_user_maps = 0` in `~/.vimrc`, and then, copy over any maps that I do want from the map file.  🤔 